### PR TITLE
Bump to time 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [dependencies]
 conduit = "0.9.0-alpha.2"
 conduit-mime-types = "0.7"
-time = "0.1"
+time = { version = "0.2", default-features = false, features = ["std"] }
 filetime = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
We don't currently use `time 0.2` downstream in crates.io, so I see no need to merge this for now.

Closes #6